### PR TITLE
fix: Unescape HTML entities in commit messages

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"html"
+
 	"github.com/erikgeiser/promptkit/confirmation"
 	"github.com/fatih/color"
 	"github.com/loveRyujin/ReviewBot/ai"
@@ -104,7 +106,7 @@ var commitCmd = &cobra.Command{
 
 		// Output commit message from AI
 		color.Yellow("================Commit Summary====================")
-		color.Yellow("\n" + commitMsg + "\n\n")
+		color.Yellow("\n" + html.UnescapeString(commitMsg) + "\n\n")
 		color.Yellow("==================================================")
 
 		if preview {


### PR DESCRIPTION
- Add html package import for unescaping strings
- Unescape HTML entities in commit message before displaying