### PR TITLE
Add commit translation support and harden command detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,19 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-ReviewBot is a Go module built around a single CLI binary. Source code lives in `cmd/reviewbot` for the executable and `pkg` for reusable packages (`pkg/command`, `pkg/form`, `pkg/progress`, `pkg/version`). Provider integrations and prompt assets reside in `ai/`, `llm/`, and `prompt/`. Configuration examples are under `config/`, while release artifacts land in `release/<platform>/`. Tests accompany their packages, e.g. `pkg/command/command_test.go` and `prompt/translation_test.go`. UI assets and demos are stored in `images/`. CI workflows are defined in `.github/workflows/`.
+ReviewBot is a Go module built around the `reviewbot` CLI. Entry commands live in `cmd/`, reusable helpers in `pkg/`, and provider integrations under `ai/` and `llm/`. Prompt templates and translation helpers are in `prompt/`. Configuration samples reside in `config/`, release builds in `release/<platform>/`, and demo assets in `images/`. Tests sit beside their packages, for example `pkg/command/command_test.go` and `prompt/translation_test.go`. CI configs live in `.github/workflows/`.
 
 ## Build, Test, and Development Commands
-- `make build`: runs `go mod tidy`, compiles the binary, and drops it in `bin/reviewbot`.
-- `make build_<target>`: cross-compiles into the matching `release/<os>/<arch>/` folder (see Makefile).
-- `go test ./...`: executes the entire test suite; use `-run` to scope changes.
-- `go run ./cmd/reviewbot --help`: quick local smoke test of CLI options.
+- `make build`: runs `go mod tidy`, compiles the binary, and emits `bin/reviewbot`.
+- `make build_<target>`: cross-compiles into `release/<os>/<arch>/` (see Makefile targets).
+- `go test ./...`: executes the full test suite; add `-run <pattern>` for narrower checks.
+- `go run ./cmd/reviewbot --help`: fast manual verification of CLI wiring.
 
 ## Coding Style & Naming Conventions
-Follow idiomatic Go style. Format all Go files with `gofmt` or `go fmt ./...` before committing. Exported types and functions use PascalCase; keep unexported helpers in lowerCamelCase. Prefer table-driven tests and keep files under 400 lines for readability. When adding prompts or configs, mirror existing naming (e.g., `prompt/template/<feature>.tmpl`, `config/reviewbot.yaml`).
+Follow idiomatic Go style. Format Go files with `gofmt` or `go fmt ./...`. Exported types and functions use PascalCase; keep unexported helpers camelCase. Prefer table-driven tests and keep files under 400 lines for readability. When adding prompts or configs, mirror the existing naming (e.g., `prompt/template/<feature>.tmpl`, `config/reviewbot.yaml`).
 
 ## Testing Guidelines
-Place tests alongside implementation using the `TestXxx` naming scheme. For features touching external services, stub providers via the abstractions in `pkg/command`. Maintain existing coverage by exercising new branches with table-driven cases. Run `go test -cover ./...` before opening a pull request, and document any gaps.
+Place tests alongside implementation using the `TestXxx` naming scheme. For features touching external services, stub providers via the adapters in `pkg/command`. Maintain coverage by exercising new branches with table-driven cases. Run `go test -cover ./...` before opening a pull request, and record any unavoidable gaps.
 
 ## Commit & Pull Request Guidelines
-Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`) as shown in the recent Git history. Group related edits and avoid mixing refactors with feature work. Pull requests should include: a concise summary, reproduction or verification steps (commands, screenshots, or GIFs when UI output changes), updated docs for configuration changes, and references to related issues or discussions.
+Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`). Group related edits and avoid mixing refactors with feature work. Pull requests should include: a concise summary, verification steps (commands, screenshots, or GIFs when output changes), updated docs for configuration changes, and links to related issues or discussions. Document translation behaviors or language additions when touching `--output_lang`.

--- a/README.md
+++ b/README.md
@@ -129,11 +129,13 @@ reviewbot config set ai.api_key xxxxxx
 reviewbot review --stream
 ```
 ![review_stream](./images/review_stream.gif)
-### 指定语言翻译（review命令支持）
-指定 --output_lang=lang，支持（en、zh-cn、zh-tw、jp）  
+### 指定语言翻译（review、commit命令支持）
+指定 --output_lang=lang，支持（en、zh-cn、zh-tw、jp） 
 
 ```sh
 reviewbot review --output_lang=zh-cn
+
+reviewbot commit --output_lang=zh-cn
 ```
 ![review_translation](./images/review_spinner_translation.gif)
 ### 从外部源获取git diff

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -1,8 +1,19 @@
 package command
 
-import "os/exec"
+import (
+	"os/exec"
+	"strings"
+)
 
+// IsCommandAvailable reports whether the given command exists on the current system PATH.
+// It trims surrounding quotes and whitespace to remain robust across Windows, macOS, and Linux.
 func IsCommandAvailable(command string) bool {
-	_, err := exec.LookPath(command)
+	name := strings.TrimSpace(command)
+	name = strings.Trim(name, "\"'")
+	if name == "" {
+		return false
+	}
+
+	_, err := exec.LookPath(name)
 	return err == nil
 }

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -1,6 +1,9 @@
 package command
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func Test_IsCommandAvailable(t *testing.T) {
 	testCases := []struct {
@@ -9,13 +12,13 @@ func Test_IsCommandAvailable(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "valid command-1",
-			command:  "pwd",
+			name:     "valid command-2",
+			command:  "git",
 			expected: true,
 		},
 		{
-			name:     "valid command-2",
-			command:  "git",
+			name:     "valid shell command",
+			command:  defaultShellCommand(),
 			expected: true,
 		},
 
@@ -34,4 +37,11 @@ func Test_IsCommandAvailable(t *testing.T) {
 			}
 		})
 	}
+}
+
+func defaultShellCommand() string {
+	if runtime.GOOS == "windows" {
+		return "cmd"
+	}
+	return "sh"
 }


### PR DESCRIPTION
 ## Summary

  - Extend reviewbot commit with --output_lang, translating generated messages and displaying only the translated text.
  - Update README and AGENTS guidelines to cover the new translation workflow and contributor expectations.
  - Harden pkg/command.IsCommandAvailable with trimming logic and cross-platform tests (Windows/macOS/Linux) to restore
  CI coverage.

  ## Testing

  - go test ./pkg/command
  - go test ./...