### PR TITLE
chore: Exclude merge commits from changelog generation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,6 +57,10 @@ changelog:
   use: github
   sort: asc
   format: "{{.SHA}}: {{.Message}} (@{{.AuthorUsername}})"
+  filters:
+    exclude:
+      - "Merge pull request"
+      - "Merge branch "
   groups:
     - title: Features
       regexp: "^.*feat[(\\w)]*:+.*$"


### PR DESCRIPTION
- Exclude merge commits from the changelog by filtering out messages containing "Merge pull request" or "Merge branch"